### PR TITLE
fix: add additional calling_station_id macaddr formats

### DIFF
--- a/raddb/mods-available/ratelimit
+++ b/raddb/mods-available/ratelimit
@@ -1,0 +1,13 @@
+# -*- text -*-
+#
+#  $Id$
+
+# RATELIMIT ...
+#
+#  http://www.openldap.org/faq/data/cache/347.html
+ratelimit {
+	refreshrate = 10
+	lograte = 5
+	tokenmax = 5
+}
+

--- a/src/modules/rlm_ratelimit/README.md
+++ b/src/modules/rlm_ratelimit/README.md
@@ -1,0 +1,9 @@
+# rlm_ratelimit
+## Metadata
+<dl>
+  <dt>category</dt><dd>policy</dd>
+</dl>
+
+## Summary
+
+Initial test version of rate limiting.

--- a/src/modules/rlm_ratelimit/all.mk
+++ b/src/modules/rlm_ratelimit/all.mk
@@ -1,0 +1,11 @@
+TARGETNAME	:= rlm_ratelimit
+
+ifneq "$(TARGETNAME)" ""
+TARGET		:= $(TARGETNAME).a
+endif
+
+SOURCES		:= $(TARGETNAME).c fixedds.c
+
+SRC_CFLAGS	:=
+TGT_LDLIBS	:=
+

--- a/src/modules/rlm_ratelimit/fixedds.c
+++ b/src/modules/rlm_ratelimit/fixedds.c
@@ -1,0 +1,122 @@
+/*
+ *   This program is is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or (at
+ *   your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/**
+ * $Id$
+ *
+ * @file fixedds.c
+ * @brief Fixed length datastore for token bucket storage.
+ *
+ * @copyright 2024 The FreeRADIUS server project
+ * @copyright 2024 your name <TODO>
+ */
+RCSID("$Id$")
+
+#include "fixedds.h"
+
+static int index_from_id(RatelimitID id, uint32_t *index);
+
+void *datastore_init(uint32_t listlength) {
+    BucketList *b;
+
+    INFO("ratelimit: datastore_init(): creating bucket store with capacity %d.", listlength);
+	b = talloc(NULL, BucketList);
+	b->buckets = (Bucket *) talloc_array_size(b, sizeof(Bucket), listlength);
+    INFO("ratelimit: datastore_init(): storage allocated: %ld bytes", talloc_total_size(b));
+	for (uint32_t i=0; i<listlength; i++) {
+		b->buckets[i].accessed = 0;
+	}
+	return b;
+}
+
+/*
+ * insert
+ */
+Bucket *insert(void *datastore, Bucket data, RatelimitID id) {
+    BucketList *list = datastore;
+	uint32_t index;
+
+    list = datastore;
+    if (index_from_id(id, &index) == -1) {
+        return NULL;
+    }
+
+    DEBUG("ratelimit: insert(): id %s inserted at index %d", id.key, index);
+
+    list->buckets[index].tokens = data.tokens;
+    list->buckets[index].accessed = data.accessed;
+    return &(list->buckets[index]);
+}
+
+/*
+ * lookup returns the entry in the datastore with the given id or NULL if the datastore
+ * doesn't contain an entry for id.
+ */
+Bucket *lookup(void *datastore, RatelimitID id) {
+    BucketList *list;
+	uint32_t index;
+
+    list = datastore;
+
+	if (index_from_id(id, &index) == -1) {
+        WARN("ratelimit: lookup(): bucket not found for id %s", id.key);
+        return NULL;
+    }
+    return &(list->buckets[index]);
+}
+
+/*
+ * index_from_id return the left most 24 bit from mac address
+ * TODO: pass in type to do a switch on.
+ */
+static int index_from_id(RatelimitID id, uint32_t *index) {
+    uint values[8];
+    uint64_t int_val;
+
+    switch (id.key_type) {
+        case MACADDR:
+            /* Contains 6 components - use the last 3 octets (extension ID) as the index */
+            if (6 == sscanf(id.key, "%x:%x:%x:%x:%x:%x",
+                &values[0], &values[1], &values[2], &values[3], &values[4], &values[5])) {
+                int_val = values[3] << 16 | values[4] << 8 | values[5];
+                (*index) = int_val;
+                return 0;
+            }
+            break;
+        case IPV4:
+            /* Contains 4 components - use the last 3 octets for the index. */
+            if (4 == sscanf(id.key, "%d.%d.%d.%d", &values[0], &values[1], &values[2], &values[3])) {
+                int_val = values[1] << 16 | values[2] << 8 | values[3];
+                (*index) = int_val;
+                return 0;
+            }
+            break;
+        case IPV6:
+            /* Contains 8 octets - use last 3 octets for the index. */
+            if (8 == sscanf(id.key, "%x:%x:%x:%x:%x:%x:%x:%x",
+                &values[0], &values[1], &values[2], &values[3], &values[4], &values[5], &values[6], &values[7])) {
+                int_val = values[5] << 16 | values[6] << 8 | values[7];
+                (*index) = int_val;
+                return 0;
+            }
+            break;
+        case NONE:
+            break;
+    }
+
+    INFO("ratelimit: index_from_id(): invalid id %s", id.key);
+    return -1;
+}

--- a/src/modules/rlm_ratelimit/fixedds.c
+++ b/src/modules/rlm_ratelimit/fixedds.c
@@ -119,9 +119,23 @@ static int index_from_id(RatelimitID id, uint32_t *index)
 	switch (id.key_type)
 	{
 	case MACADDR:
-		/* Contains 6 components - use the last 3 octets (extension ID) as the index */
-		if (6 == sscanf(id.key, "%x:%x:%x:%x:%x:%x",
+		/*
+		 * Contains 6 components - use the last 3 octets (extension ID) as the index
+		 * In one of these formats:
+		 *    "8C:F0:71:C0:00:26"
+		 *    "8C-F0-71-C0-00-26"
+		 *    "8CF071C00026"
+		 *    "8CF0.71C0.0026"
+		*/
+		if ((6 == sscanf(id.key, "%x:%x:%x:%x:%x:%x",
+			&values[0], &values[1], &values[2], &values[3], &values[4], &values[5])) ||
+			(6 == sscanf(id.key, "%x-%x-%x-%x-%x-%x",
+			&values[0], &values[1], &values[2], &values[3], &values[4], &values[5])) ||
+			(6 == sscanf(id.key, "%2x%2x%2x%2x%2x%2x",
+			&values[0], &values[1], &values[2], &values[3], &values[4], &values[5])) ||
+			(6 == sscanf(id.key, "%2x%2x.%2x%2x.%2x%2x",
 			&values[0], &values[1], &values[2], &values[3], &values[4], &values[5]))
+			)
 		{
 			int_val = values[3] << 16 | values[4] << 8 | values[5];
 			(*index) = int_val;

--- a/src/modules/rlm_ratelimit/fixedds.c
+++ b/src/modules/rlm_ratelimit/fixedds.c
@@ -27,11 +27,11 @@ RCSID("$Id$")
 
 #include "fixedds.h"
 
-static int index_from_id(RatelimitID id, uint32_t* index);
+static int index_from_id(RatelimitID id, uint32_t *index);
 
-void* datastore_init(uint32_t listlength)
+void *datastore_init(uint32_t listlength)
 {
-	BucketList* b;
+	BucketList *b;
 
 	INFO("ratelimit: datastore_init(): creating bucket store with capacity %d.", listlength);
 	INFO("ratelimit: datastore_init(): total capacity %lu.", sizeof(Bucket) * listlength);
@@ -39,11 +39,11 @@ void* datastore_init(uint32_t listlength)
 	b = talloc(NULL, BucketList);
 	fr_assert(b != NULL);
 
-	b->tokens = (uint8_t*)talloc_array_size(b, sizeof(uint8_t), listlength);
+	b->tokens = (uint8_t *)talloc_array_size(b, sizeof(uint8_t), listlength);
 	fr_assert(b->tokens != NULL);
-	b->accessed = (uint64_t*)talloc_array_size(b, sizeof(uint64_t), listlength);
+	b->accessed = (uint64_t *)talloc_array_size(b, sizeof(uint64_t), listlength);
 	fr_assert(b->accessed != NULL);
-	b->lastlogged = (uint64_t*)talloc_array_size(b, sizeof(uint64_t), listlength);
+	b->lastlogged = (uint64_t *)talloc_array_size(b, sizeof(uint64_t), listlength);
 	fr_assert(b->lastlogged != NULL);
 
 	DEBUG("ratelimit: datastore_init(): storage allocated: %ld bytes", talloc_total_size(b));
@@ -61,9 +61,9 @@ void* datastore_init(uint32_t listlength)
 /*
  * insert
  */
-Bucket* insert(void* datastore, Bucket data, RatelimitID id, Bucket* buffer)
+Bucket *insert(void *datastore, Bucket data, RatelimitID id, Bucket *buffer)
 {
-	BucketList* list = datastore;
+	BucketList *list = datastore;
 	uint32_t index;
 
 	list = datastore;
@@ -88,9 +88,9 @@ Bucket* insert(void* datastore, Bucket data, RatelimitID id, Bucket* buffer)
  * lookup returns the entry in the datastore with the given id or NULL if the datastore
  * doesn't contain an entry for id.
  */
-Bucket* lookup(void* datastore, RatelimitID id, Bucket* buffer)
+Bucket *lookup(void *datastore, RatelimitID id, Bucket *buffer)
 {
-	BucketList* list;
+	BucketList *list;
 	uint32_t index;
 
 	list = datastore;
@@ -111,7 +111,7 @@ Bucket* lookup(void* datastore, RatelimitID id, Bucket* buffer)
  * index_from_id return the left most 24 bit from mac address
  * TODO: pass in type to do a switch on.
  */
-static int index_from_id(RatelimitID id, uint32_t* index)
+static int index_from_id(RatelimitID id, uint32_t *index)
 {
 	uint values[8];
 	uint64_t int_val;

--- a/src/modules/rlm_ratelimit/fixedds.c
+++ b/src/modules/rlm_ratelimit/fixedds.c
@@ -14,109 +14,143 @@
  *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-/**
- * $Id$
- *
- * @file fixedds.c
- * @brief Fixed length datastore for token bucket storage.
- *
- * @copyright 2024 The FreeRADIUS server project
- * @copyright 2024 your name <TODO>
- */
+ /**
+  * $Id$
+  *
+  * @file fixedds.c
+  * @brief Fixed length datastore for token bucket storage.
+  *
+  * @copyright 2024 The FreeRADIUS server project
+  * @copyright 2024 your name <TODO>
+  */
 RCSID("$Id$")
 
 #include "fixedds.h"
 
-static int index_from_id(RatelimitID id, uint32_t *index);
+static int index_from_id(RatelimitID id, uint32_t* index);
 
-void *datastore_init(uint32_t listlength) {
-    BucketList *b;
+void* datastore_init(uint32_t listlength)
+{
+	BucketList* b;
 
-    INFO("ratelimit: datastore_init(): creating bucket store with capacity %d.", listlength);
+	INFO("ratelimit: datastore_init(): creating bucket store with capacity %d.", listlength);
+	INFO("ratelimit: datastore_init(): total capacity %lu.", sizeof(Bucket) * listlength);
+
 	b = talloc(NULL, BucketList);
-	b->buckets = (Bucket *) talloc_array_size(b, sizeof(Bucket), listlength);
-    INFO("ratelimit: datastore_init(): storage allocated: %ld bytes", talloc_total_size(b));
-	for (uint32_t i=0; i<listlength; i++) {
-		b->buckets[i].accessed = 0;
+	fr_assert(b != NULL);
+
+	b->tokens = (uint8_t*)talloc_array_size(b, sizeof(uint8_t), listlength);
+	fr_assert(b->tokens != NULL);
+	b->accessed = (uint64_t*)talloc_array_size(b, sizeof(uint64_t), listlength);
+	fr_assert(b->accessed != NULL);
+	b->lastlogged = (uint64_t*)talloc_array_size(b, sizeof(uint64_t), listlength);
+	fr_assert(b->lastlogged != NULL);
+
+	DEBUG("ratelimit: datastore_init(): storage allocated: %ld bytes", talloc_total_size(b));
+
+	for (uint32_t i = 0; i < listlength; i++)
+	{
+		b->tokens[i] = 0;
+		b->accessed[i] = 0;
+		b->lastlogged[i] = 0;
 	}
+
 	return b;
 }
 
 /*
  * insert
  */
-Bucket *insert(void *datastore, Bucket data, RatelimitID id) {
-    BucketList *list = datastore;
+Bucket* insert(void* datastore, Bucket data, RatelimitID id, Bucket* buffer)
+{
+	BucketList* list = datastore;
 	uint32_t index;
 
-    list = datastore;
-    if (index_from_id(id, &index) == -1) {
-        return NULL;
-    }
+	list = datastore;
+	if (index_from_id(id, &index) == -1)
+	{
+		return NULL;
+	}
 
-    DEBUG("ratelimit: insert(): id %s inserted at index %d", id.key, index);
+	DEBUG("ratelimit: insert(): id %s inserted at index %d", id.key, index);
 
-    list->buckets[index].tokens = data.tokens;
-    list->buckets[index].accessed = data.accessed;
-    return &(list->buckets[index]);
+	list->tokens[index] = data.ntokens;
+	list->accessed[index] = data.lastaccessed;
+	list->lastlogged[index] = data.lastlogged;
+
+	buffer->ntokens = &(list->tokens[index]);
+	buffer->lastlogged = &(list->lastlogged[index]);
+
+	return buffer;
 }
 
 /*
  * lookup returns the entry in the datastore with the given id or NULL if the datastore
  * doesn't contain an entry for id.
  */
-Bucket *lookup(void *datastore, RatelimitID id) {
-    BucketList *list;
+Bucket* lookup(void* datastore, RatelimitID id, Bucket* buffer)
+{
+	BucketList* list;
 	uint32_t index;
 
-    list = datastore;
+	list = datastore;
 
-	if (index_from_id(id, &index) == -1) {
-        WARN("ratelimit: lookup(): bucket not found for id %s", id.key);
-        return NULL;
-    }
-    return &(list->buckets[index]);
+	if (index_from_id(id, &index) == -1)
+	{
+		WARN("ratelimit: lookup(): bucket not found for id %s", id.key);
+		return NULL;
+	}
+
+	buffer->ntokens = &(list->tokens[index]);
+	buffer->lastaccessed = &(list->accessed[index]);
+	buffer->lastlogged = &(list->lastlogged[index]);
+	return buffer;
 }
 
 /*
  * index_from_id return the left most 24 bit from mac address
  * TODO: pass in type to do a switch on.
  */
-static int index_from_id(RatelimitID id, uint32_t *index) {
-    uint values[8];
-    uint64_t int_val;
+static int index_from_id(RatelimitID id, uint32_t* index)
+{
+	uint values[8];
+	uint64_t int_val;
 
-    switch (id.key_type) {
-        case MACADDR:
-            /* Contains 6 components - use the last 3 octets (extension ID) as the index */
-            if (6 == sscanf(id.key, "%x:%x:%x:%x:%x:%x",
-                &values[0], &values[1], &values[2], &values[3], &values[4], &values[5])) {
-                int_val = values[3] << 16 | values[4] << 8 | values[5];
-                (*index) = int_val;
-                return 0;
-            }
-            break;
-        case IPV4:
-            /* Contains 4 components - use the last 3 octets for the index. */
-            if (4 == sscanf(id.key, "%d.%d.%d.%d", &values[0], &values[1], &values[2], &values[3])) {
-                int_val = values[1] << 16 | values[2] << 8 | values[3];
-                (*index) = int_val;
-                return 0;
-            }
-            break;
-        case IPV6:
-            /* Contains 8 octets - use last 3 octets for the index. */
-            if (8 == sscanf(id.key, "%x:%x:%x:%x:%x:%x:%x:%x",
-                &values[0], &values[1], &values[2], &values[3], &values[4], &values[5], &values[6], &values[7])) {
-                int_val = values[5] << 16 | values[6] << 8 | values[7];
-                (*index) = int_val;
-                return 0;
-            }
-            break;
-        case NONE:
-            break;
-    }
+	switch (id.key_type)
+	{
+	case MACADDR:
+		/* Contains 6 components - use the last 3 octets (extension ID) as the index */
+		if (6 == sscanf(id.key, "%x:%x:%x:%x:%x:%x",
+			&values[0], &values[1], &values[2], &values[3], &values[4], &values[5]))
+		{
+			int_val = values[3] << 16 | values[4] << 8 | values[5];
+			(*index) = int_val;
+			return 0;
+		}
+		break;
+	case IPV4:
+		/* Contains 4 components - use the last 3 octets for the index. */
+		if (4 == sscanf(id.key, "%d.%d.%d.%d", &values[0], &values[1], &values[2], &values[3]))
+		{
+			int_val = values[1] << 16 | values[2] << 8 | values[3];
+			(*index) = int_val;
+			return 0;
+		}
+		break;
+	case IPV6:
+		/* Contains 8 octets - use last 3 octets for the index. */
+		if (8 == sscanf(id.key, "%x:%x:%x:%x:%x:%x:%x:%x",
+			&values[0], &values[1], &values[2], &values[3], &values[4], &values[5], &values[6], &values[7]))
+		{
+			int_val = values[5] << 16 | values[6] << 8 | values[7];
+			(*index) = int_val;
+			return 0;
+		}
+		break;
+	case NONE:
+		break;
+	}
 
-    INFO("ratelimit: index_from_id(): invalid id %s", id.key);
-    return -1;
+	INFO("ratelimit: index_from_id(): invalid id %s", id.key);
+	return -1;
 }

--- a/src/modules/rlm_ratelimit/fixedds.h
+++ b/src/modules/rlm_ratelimit/fixedds.h
@@ -1,0 +1,48 @@
+/*
+ *   This program is is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or (at
+ *   your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/**
+ * $Id$
+ *
+ * @file fixedds.h
+ * @brief Fixed length datastore for token bucket storage.
+ *
+ * @copyright 2024 The FreeRADIUS server project
+ * @copyright 2024 your name \<your address\>
+ */
+RCSIDH(fixedds_h, "$Id$")
+
+#include <freeradius-devel/radiusd.h>
+
+enum IDType { NONE, MACADDR, IPV4, IPV6 };
+
+typedef struct RatelimitID {
+    const char *key;
+    enum IDType key_type;
+} RatelimitID;
+
+typedef struct Bucket {
+    uint8_t tokens;
+    uint64_t accessed;
+} Bucket;
+
+typedef struct BucketList {
+    Bucket *buckets;
+} BucketList;
+
+void *datastore_init(uint32_t listlength);
+Bucket *insert(void *datastore, Bucket data, RatelimitID id);
+Bucket *lookup(void *datastore, RatelimitID id);

--- a/src/modules/rlm_ratelimit/fixedds.h
+++ b/src/modules/rlm_ratelimit/fixedds.h
@@ -14,15 +14,15 @@
  *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-/**
- * $Id$
- *
- * @file fixedds.h
- * @brief Fixed length datastore for token bucket storage.
- *
- * @copyright 2024 The FreeRADIUS server project
- * @copyright 2024 your name \<your address\>
- */
+ /**
+  * $Id$
+  *
+  * @file fixedds.h
+  * @brief Fixed length datastore for token bucket storage.
+  *
+  * @copyright 2024 The FreeRADIUS server project
+  * @copyright 2024 your name \<your address\>
+  */
 RCSIDH(fixedds_h, "$Id$")
 
 #include <freeradius-devel/radiusd.h>
@@ -30,20 +30,20 @@ RCSIDH(fixedds_h, "$Id$")
 enum IDType { NONE, MACADDR, IPV4, IPV6 };
 
 typedef struct RatelimitID {
-    const char *key;
-    enum IDType key_type;
+	const char *key;
+	enum IDType key_type;
 } RatelimitID;
 
 typedef struct Bucket {
-    uint8_t *ntokens;
-    uint64_t *lastaccessed;
-    uint64_t *lastlogged;
+	uint8_t *ntokens;
+	uint64_t *lastaccessed;
+	uint64_t *lastlogged;
 } Bucket;
 
 typedef struct BucketList {
-    uint8_t *tokens;
-    uint64_t *accessed;
-    uint64_t *lastlogged;
+	uint8_t *tokens;
+	uint64_t *accessed;
+	uint64_t *lastlogged;
 } BucketList;
 
 typedef int32_t BucketRef;

--- a/src/modules/rlm_ratelimit/fixedds.h
+++ b/src/modules/rlm_ratelimit/fixedds.h
@@ -35,14 +35,19 @@ typedef struct RatelimitID {
 } RatelimitID;
 
 typedef struct Bucket {
-    uint8_t tokens;
-    uint64_t accessed;
+    uint8_t *ntokens;
+    uint64_t *lastaccessed;
+    uint64_t *lastlogged;
 } Bucket;
 
 typedef struct BucketList {
-    Bucket *buckets;
+    uint8_t *tokens;
+    uint64_t *accessed;
+    uint64_t *lastlogged;
 } BucketList;
 
+typedef int32_t BucketRef;
+
 void *datastore_init(uint32_t listlength);
-Bucket *insert(void *datastore, Bucket data, RatelimitID id);
-Bucket *lookup(void *datastore, RatelimitID id);
+Bucket *insert(void *datastore, Bucket data, RatelimitID id, Bucket *b);
+Bucket *lookup(void *datastore, RatelimitID id, Bucket *b);

--- a/src/modules/rlm_ratelimit/rlm_ratelimit.c
+++ b/src/modules/rlm_ratelimit/rlm_ratelimit.c
@@ -1,0 +1,345 @@
+/*
+ *   This program is is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or (at
+ *   your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/**
+ * $Id$
+ *
+ * @file rlm_ratelimit.c
+ * @brief Allow FreeRADIUS to rate limit requests.
+ *
+ * @copyright 2024 The FreeRADIUS server project
+ * @copyright 2024 your name <TODO>
+ */
+RCSID("$Id$")
+
+#include "fixedds.h"
+#include "rlm_ratelimit.h"
+
+typedef Bucket* bucketRef;
+
+static bucketRef add_bucket(rlm_ratelimit_t *inst, RatelimitID id);
+static uint64_t current_time_in_sec(void);
+static Bucket* get_bucket(rlm_ratelimit_t *inst, RatelimitID id);
+static int id_from_request(RatelimitID *id, REQUEST *request, char* buffer, uint bsize);
+static void log_ratelimit(RatelimitID id);
+static void *ratelimit_init_datastore(rlm_ratelimit_t *instance);
+static bool ratelimit_ok(rlm_ratelimit_t *inst, RatelimitID id);
+static uint tokens_to_add(uint64_t elapsed, uint32_t refreshrate);
+static bool valid_bucket(Bucket *b);
+static void update_bucket_tokens(Bucket *b, uint32_t maxtokens, uint32_t refreshrate);
+static void update_used_bucket(Bucket *b);
+
+static uint numbuckets; /* TODO: used for debugging. Remove? */
+
+
+/*
+ * ratelimit_init_datastore calls hashtable_init to create and return a backend datastore.
+ */
+static void *ratelimit_init_datastore(rlm_ratelimit_t *instance) {
+	INFO("ratelimit: using a fix size array");
+	return datastore_init(instance->datastoresize);
+}
+
+/*
+ * add_bucket creates a new CSID token bucket, insert it into the datastore and returns a reference to it.
+ */
+static bucketRef add_bucket(rlm_ratelimit_t *inst, RatelimitID id) {
+	Bucket b;
+
+	b.tokens = inst->tokenmax;
+	b.accessed = current_time_in_sec();
+	DEBUG("ratelimit: add_bucket() created bucket for ID %s. Total allocated buckets: %d", id.key, ++numbuckets);
+	return insert(inst->datastore, b, id);
+}
+
+/*
+ * update_used_bucket decrements the token count and updates last access time
+ */
+static void update_used_bucket(Bucket *b) {
+	if (!valid_bucket(b)) {
+		ERROR("ratelimit: update_used_bucket(): bucket index out of range");
+	}
+	b->tokens--;
+	b->accessed = current_time_in_sec();
+}
+
+/*
+ * update_bucket_tokens determines if the bucket's tokens can be replenished. If so,
+ * it is replenished up to, but not exceeding, TOKENMAX.
+ */
+static void update_bucket_tokens(Bucket *b, uint32_t maxtokens, uint32_t refreshrate) {
+	uint nTokens;
+	uint32_t toks_to_add;
+
+	if (!valid_bucket(b)) {
+		ERROR("ratelimit: update_bucket_tokens(): invalid bucket");
+		return;
+	}
+
+	nTokens = tokens_to_add(current_time_in_sec() - b->accessed, refreshrate);
+	DEBUG("ratelimit: update_bucket_tokens(): nTokens: %d", nTokens);
+	toks_to_add = (b->tokens+nTokens <= (uint) maxtokens) ? b->tokens+nTokens : maxtokens;
+	b->tokens = toks_to_add;
+}
+
+/*
+ * tokens_to_add returns the number of tokens to add for the elapse time for the update_period
+ */
+static uint tokens_to_add(uint64_t elapsed, uint32_t refreshrate) {
+	DEBUG("ratelimit: tokens_to_add(): elapsed: %llu refreshrate %d", elapsed, refreshrate);
+	return elapsed / refreshrate;
+}
+
+/*
+ *  valid_bucket return true if the bucketRef is valid
+ */
+static bool valid_bucket(Bucket *b) {
+	if (b != NULL) {
+		return true;
+	}
+	return false;
+}
+
+/*
+ * current_time_in_sec returns the current time in seconds since UNIX Epoch.
+ */
+static uint64_t current_time_in_sec(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return ts.tv_sec;
+}
+
+/*
+ * get_bucket returns a reference to the token bucket with the specified id. If the id
+ * doesn't exist a new bucket is created and a reference to the new bucket is
+ * returned.
+ */
+static Bucket* get_bucket(rlm_ratelimit_t *inst, RatelimitID id) {
+	Bucket *b = NULL;
+
+	b = lookup(inst->datastore, id);
+
+	/* bucket for ID doesn't exist. Add one. */
+	if (b == NULL) {
+		DEBUG("ratelimit: get_bucket(): bucket not found. Adding bucket: %s", id.key);
+		b = add_bucket(inst, id);
+	}
+
+	DEBUG("ratelimit: getbucket(): %s %d %llu", id.key, b->tokens, b->accessed);
+	return b;
+}
+
+/*
+ * ratelimit_ok returns true if the rate limit for RatelimitID hasn't been exceeded.
+ */
+static bool ratelimit_ok(rlm_ratelimit_t *inst, RatelimitID id) {
+	Bucket *b;
+
+	DEBUG("ratelimit: ratelimit_ok(): checking rate limit for %s", id.key);
+
+	/*
+	 * get the bucket for id. Update tokens to account for elapsed time since it
+	 * it was last accessed. Return false if the bucket has run out of tokens.
+	 */
+	b = get_bucket(inst, id);
+	update_bucket_tokens(b, inst->tokenmax, inst->refreshrate);
+	if (b->tokens <= 0) {
+		return false;
+	}
+
+	/* the request is within limits - update the bucket and return "OK" (true) */
+	update_used_bucket(b);
+	return true;
+}
+
+/*
+ * log_ratelimit logs the ratelimit event for the RatelimitID.
+ */
+static void log_ratelimit(RatelimitID id) {
+	WARN("ratelimit: request id %s ratelimited", id.key);
+}
+
+/*
+ * If configuration information is given in the config section
+ * that must be referenced in later calls, store a handle to it
+ * in *instance otherwise put a null pointer there.
+ */
+static int mod_instantiate(UNUSED CONF_SECTION *conf, void *instance) {
+	rlm_ratelimit_t *inst = instance;
+
+	/* trivial sanity check on config values passed in */
+	rad_assert(inst->datastoresize > 0);
+	rad_assert(inst->tokenmax > 0);
+	rad_assert(inst->refreshrate > 0);
+
+	inst->datastore = ratelimit_init_datastore(inst);
+	if (inst->datastore == NULL) {
+		return -1;
+	}
+
+	return 0;
+}
+
+#ifdef WITH_ACCOUNTING
+/*
+ * Massage the request before recording it or proxying it
+ */
+static rlm_rcode_t CC_HINT(nonnull) mod_preacct(UNUSED void *instance, UNUSED REQUEST *request) {
+	return RLM_MODULE_OK;
+}
+
+/*
+ * Write accounting information to this modules database.
+ */
+static rlm_rcode_t CC_HINT(nonnull) mod_accounting(UNUSED void *instance, UNUSED REQUEST *request) {
+	return RLM_MODULE_OK;
+}
+
+/*
+ * See if a user is already logged in. Sets request->simul_count to the
+ * current session count for this user and sets request->simul_mpp to 2
+ * if it looks like a multilink attempt based on the requested IP
+ * address, otherwise leaves request->simul_mpp alone.
+ *
+ * Check twice. If on the first pass the user exceeds his
+ * max. number of logins, do a second pass and validate all
+ * logins by querying the terminal server (using eg. SNMP).
+ */
+static rlm_rcode_t CC_HINT(nonnull) mod_checksimul(UNUSED void *instance, REQUEST *request) {
+	request->simul_count=0;
+
+	return RLM_MODULE_OK;
+}
+#endif
+
+/*
+ * Only free memory we allocated.  The strings allocated via
+ * cf_section_parse() do not need to be freed.
+ */
+static int mod_detach(void *instance) {
+	rlm_ratelimit_t *inst = instance;
+
+	talloc_free(inst->datastore);
+
+	/*
+	 * We need to explicitly free all children, so if the driver
+	 * parented any memory off the instance, their destructors
+	 * run before we unload the bytecode for them.
+	 *
+	 * If we don't do this, we get a SEGV deep inside the talloc code
+	 * when it tries to call a destructor that no longer exists.
+	 */
+	talloc_free_children(inst);
+
+	return 0;
+}
+
+/*
+ * id_from_request creates a RatelimitID for the request. The ID is created from the
+ * the calling_station_id attribute. If request doesn't contain a calling_station_id
+ * the ReatelimitID is created from the request's source IP address, which require
+ * the buffer and bsize arguments.
+ *
+ * Returns 0 on success or -1 on error.
+ */
+static int id_from_request(RatelimitID *id, REQUEST *request, char *buffer, uint bsize) {
+	VALUE_PAIR *vp;
+	const char *ip;
+
+	/* create the ID from the calling_station_id if present */
+	vp = fr_pair_find_by_num(request->packet->vps, PW_CALLING_STATION_ID, 0, TAG_ANY);
+	if (vp) {
+		id->key = vp->vp_strvalue;
+		id->key_type = MACADDR;
+		return 0;
+	}
+
+	/* no calling_station_id attribute so fall back to using the src_ip (ipv4 or ipv6) */
+	ip = inet_ntop(request->packet->src_ipaddr.af, &request->packet->src_ipaddr.ipaddr, buffer, bsize);
+	if (ip) {
+		id->key = ip;
+		if (request->packet->src_ipaddr.af == AF_INET) {
+			id->key_type = IPV4;
+		} else if (request->packet->src_ipaddr.af == AF_INET6) {
+			id->key_type = IPV6;
+		} else {
+			id->key_type = NONE;
+		}
+		return 0;
+	}
+
+	return -1;
+}
+
+/*
+ * Retrieve the calling_station_id from the request and return a RLM_MODULE_REJECT if the
+ * request for this session exceeds the rate limit.
+ * Return OK/NOP if the request doesn't contain a calling_station_id.
+ */
+static rlm_rcode_t CC_HINT(nonnull) mod_pre_proxy(void *instance, REQUEST *request) {
+	rlm_ratelimit_t *inst = instance;
+	int ok;
+	RatelimitID id;
+
+    /* retrieve the calling_station_id from the request */
+	if (request->packet->code == PW_CODE_ACCESS_REQUEST) {
+		char buffer[128];
+		ok = id_from_request(&id, request, buffer, sizeof(buffer));
+		if (ok == 0) {
+			DEBUG("ratelimit: id returned from request: %s", id.key);
+			if (!ratelimit_ok(inst, id)) {
+				log_ratelimit(id);
+				return RLM_MODULE_REJECT;
+			}
+		} else {
+			WARN("ratelimit: neither calling_station_id nor client_IP contained in the request");
+		}
+	}
+
+	/* TODO: should this be a RLM_MODULE_NOP? */
+	return RLM_MODULE_OK;
+}
+
+/*
+ * The module name should be the only globally exported symbol.
+ * That is, everything else should be 'static'.
+ *
+ * If the module needs to temporarily modify it's instantiation
+ * data, the type should be changed to RLM_TYPE_THREAD_UNSAFE.
+ * The server will then take care of ensuring that the module
+ * is single-threaded.
+ */
+extern module_t rlm_ratelimit;
+module_t rlm_ratelimit = {
+	.magic		= RLM_MODULE_INIT,
+	.name		= "ratelimit",
+	.type		= RLM_TYPE_THREAD_SAFE,
+	.inst_size	= sizeof(rlm_ratelimit_t),
+	.config		= module_config,
+	.instantiate	= mod_instantiate,
+	.detach		= mod_detach,
+	.methods = {
+		// [MOD_AUTHENTICATE]	= mod_authenticate,
+		// [MOD_AUTHORIZE]		= mod_authorize,
+		[MOD_PRE_PROXY]		= mod_pre_proxy,
+#ifdef WITH_ACCOUNTING
+		[MOD_PREACCT]		= mod_preacct,
+		[MOD_ACCOUNTING]	= mod_accounting,
+		[MOD_SESSION]		= mod_checksimul
+#endif
+	},
+};
+

--- a/src/modules/rlm_ratelimit/rlm_ratelimit.c
+++ b/src/modules/rlm_ratelimit/rlm_ratelimit.c
@@ -28,10 +28,10 @@ RCSID("$Id$")
 #include "fixedds.h"
 #include "rlm_ratelimit.h"
 
-static Bucket* add_bucket(rlm_ratelimit_t *inst, RatelimitID id);
+static Bucket *add_bucket(rlm_ratelimit_t *inst, RatelimitID id);
 static uint64_t current_time_in_sec(void);
-static Bucket* get_bucket(rlm_ratelimit_t *inst, RatelimitID id);
-static int id_from_request(RatelimitID *id, REQUEST *request, char* buffer, uint bsize);
+static Bucket *get_bucket(rlm_ratelimit_t *inst, RatelimitID id);
+static int id_from_request(RatelimitID *id, REQUEST *request, char *buffer, uint bsize);
 static void log_ratelimit(Bucket *b, RatelimitID id, uint32_t lograte);
 static void *ratelimit_init_datastore(rlm_ratelimit_t *instance);
 static bool ratelimit_ok(rlm_ratelimit_t *inst, RatelimitID id);
@@ -90,7 +90,7 @@ static void update_bucket_tokens(Bucket *b, uint32_t maxtokens, uint32_t refresh
 	}
 
 	nTokens = tokens_to_add(current_time_in_sec() - *(b)->lastaccessed, refreshrate);
-	toks_to_add = (*(b)->ntokens+nTokens <= (uint) maxtokens) ? *(b)->ntokens+nTokens : maxtokens;
+	toks_to_add = (*(b)->ntokens + nTokens <= (uint)maxtokens) ? *(b)->ntokens + nTokens : maxtokens;
 	*(b)->ntokens = toks_to_add;
 }
 
@@ -116,9 +116,9 @@ static bool valid_bucket(Bucket *b) {
  * current_time_in_sec returns the current time in seconds since UNIX Epoch.
  */
 static uint64_t current_time_in_sec(void) {
-    struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
-    return ts.tv_sec;
+	struct timespec ts;
+	clock_gettime(CLOCK_REALTIME, &ts);
+	return ts.tv_sec;
 }
 
 /*
@@ -126,7 +126,7 @@ static uint64_t current_time_in_sec(void) {
  * doesn't exist a new bucket is created and a reference to the new bucket is
  * returned.
  */
-static Bucket* get_bucket(rlm_ratelimit_t *inst, RatelimitID id) {
+static Bucket *get_bucket(rlm_ratelimit_t *inst, RatelimitID id) {
 	Bucket *b = NULL;
 	Bucket buffer;
 
@@ -227,7 +227,7 @@ static rlm_rcode_t CC_HINT(nonnull) mod_accounting(UNUSED void *instance, UNUSED
  * logins by querying the terminal server (using eg. SNMP).
  */
 static rlm_rcode_t CC_HINT(nonnull) mod_checksimul(UNUSED void *instance, REQUEST *request) {
-	request->simul_count=0;
+	request->simul_count = 0;
 
 	return RLM_MODULE_OK;
 }
@@ -302,7 +302,7 @@ static rlm_rcode_t CC_HINT(nonnull) mod_pre_proxy(void *instance, REQUEST *reque
 	int ok;
 	RatelimitID id;
 
-    /* retrieve the calling_station_id from the request */
+	/* retrieve the calling_station_id from the request */
 	if (request->packet->code == PW_CODE_ACCESS_REQUEST) {
 		char buffer[128];
 		ok = id_from_request(&id, request, buffer, sizeof(buffer));
@@ -331,21 +331,21 @@ static rlm_rcode_t CC_HINT(nonnull) mod_pre_proxy(void *instance, REQUEST *reque
  */
 extern module_t rlm_ratelimit;
 module_t rlm_ratelimit = {
-	.magic		= RLM_MODULE_INIT,
-	.name		= "ratelimit",
-	.type		= RLM_TYPE_THREAD_SAFE,
-	.inst_size	= sizeof(rlm_ratelimit_t),
-	.config		= module_config,
-	.instantiate	= mod_instantiate,
-	.detach		= mod_detach,
+	.magic = RLM_MODULE_INIT,
+	.name = "ratelimit",
+	.type = RLM_TYPE_THREAD_SAFE,
+	.inst_size = sizeof(rlm_ratelimit_t),
+	.config = module_config,
+	.instantiate = mod_instantiate,
+	.detach = mod_detach,
 	.methods = {
 		// [MOD_AUTHENTICATE]	= mod_authenticate,
 		// [MOD_AUTHORIZE]		= mod_authorize,
-		[MOD_PRE_PROXY]		= mod_pre_proxy,
+		[MOD_PRE_PROXY] = mod_pre_proxy,
 #ifdef WITH_ACCOUNTING
-		[MOD_PREACCT]		= mod_preacct,
-		[MOD_ACCOUNTING]	= mod_accounting,
-		[MOD_SESSION]		= mod_checksimul
+		[MOD_PREACCT] = mod_preacct,
+		[MOD_ACCOUNTING] = mod_accounting,
+		[MOD_SESSION] = mod_checksimul
 #endif
 	},
 };

--- a/src/modules/rlm_ratelimit/rlm_ratelimit.c
+++ b/src/modules/rlm_ratelimit/rlm_ratelimit.c
@@ -28,13 +28,11 @@ RCSID("$Id$")
 #include "fixedds.h"
 #include "rlm_ratelimit.h"
 
-typedef Bucket* bucketRef;
-
-static bucketRef add_bucket(rlm_ratelimit_t *inst, RatelimitID id);
+static Bucket* add_bucket(rlm_ratelimit_t *inst, RatelimitID id);
 static uint64_t current_time_in_sec(void);
 static Bucket* get_bucket(rlm_ratelimit_t *inst, RatelimitID id);
 static int id_from_request(RatelimitID *id, REQUEST *request, char* buffer, uint bsize);
-static void log_ratelimit(RatelimitID id);
+static void log_ratelimit(Bucket *b, RatelimitID id, uint32_t lograte);
 static void *ratelimit_init_datastore(rlm_ratelimit_t *instance);
 static bool ratelimit_ok(rlm_ratelimit_t *inst, RatelimitID id);
 static uint tokens_to_add(uint64_t elapsed, uint32_t refreshrate);
@@ -56,13 +54,14 @@ static void *ratelimit_init_datastore(rlm_ratelimit_t *instance) {
 /*
  * add_bucket creates a new CSID token bucket, insert it into the datastore and returns a reference to it.
  */
-static bucketRef add_bucket(rlm_ratelimit_t *inst, RatelimitID id) {
+static Bucket *add_bucket(rlm_ratelimit_t *inst, RatelimitID id) {
 	Bucket b;
+	Bucket buffer;
 
-	b.tokens = inst->tokenmax;
-	b.accessed = current_time_in_sec();
+	b.ntokens = inst->tokenmax;
+	b.lastaccessed = current_time_in_sec();
 	DEBUG("ratelimit: add_bucket() created bucket for ID %s. Total allocated buckets: %d", id.key, ++numbuckets);
-	return insert(inst->datastore, b, id);
+	return insert(inst->datastore, b, id, &buffer);
 }
 
 /*
@@ -72,8 +71,9 @@ static void update_used_bucket(Bucket *b) {
 	if (!valid_bucket(b)) {
 		ERROR("ratelimit: update_used_bucket(): bucket index out of range");
 	}
-	b->tokens--;
-	b->accessed = current_time_in_sec();
+
+	(*(b->ntokens))--;
+	*(b->lastaccessed) = current_time_in_sec();
 }
 
 /*
@@ -89,10 +89,9 @@ static void update_bucket_tokens(Bucket *b, uint32_t maxtokens, uint32_t refresh
 		return;
 	}
 
-	nTokens = tokens_to_add(current_time_in_sec() - b->accessed, refreshrate);
-	DEBUG("ratelimit: update_bucket_tokens(): nTokens: %d", nTokens);
-	toks_to_add = (b->tokens+nTokens <= (uint) maxtokens) ? b->tokens+nTokens : maxtokens;
-	b->tokens = toks_to_add;
+	nTokens = tokens_to_add(current_time_in_sec() - *(b)->lastaccessed, refreshrate);
+	toks_to_add = (*(b)->ntokens+nTokens <= (uint) maxtokens) ? *(b)->ntokens+nTokens : maxtokens;
+	*(b)->ntokens = toks_to_add;
 }
 
 /*
@@ -129,16 +128,18 @@ static uint64_t current_time_in_sec(void) {
  */
 static Bucket* get_bucket(rlm_ratelimit_t *inst, RatelimitID id) {
 	Bucket *b = NULL;
+	Bucket buffer;
 
-	b = lookup(inst->datastore, id);
+	b = lookup(inst->datastore, id, &buffer);
 
 	/* bucket for ID doesn't exist. Add one. */
 	if (b == NULL) {
 		DEBUG("ratelimit: get_bucket(): bucket not found. Adding bucket: %s", id.key);
 		b = add_bucket(inst, id);
+		INFO("ratelimit: after add_bucket tokens %d", *(b->ntokens));
 	}
 
-	DEBUG("ratelimit: getbucket(): %s %d %llu", id.key, b->tokens, b->accessed);
+	DEBUG("ratelimit: getbucket(): %s %d %llu %llu", id.key, *(b->ntokens), *(b->lastaccessed), *(b->lastlogged));
 	return b;
 }
 
@@ -146,7 +147,7 @@ static Bucket* get_bucket(rlm_ratelimit_t *inst, RatelimitID id) {
  * ratelimit_ok returns true if the rate limit for RatelimitID hasn't been exceeded.
  */
 static bool ratelimit_ok(rlm_ratelimit_t *inst, RatelimitID id) {
-	Bucket *b;
+	Bucket b;
 
 	DEBUG("ratelimit: ratelimit_ok(): checking rate limit for %s", id.key);
 
@@ -154,22 +155,28 @@ static bool ratelimit_ok(rlm_ratelimit_t *inst, RatelimitID id) {
 	 * get the bucket for id. Update tokens to account for elapsed time since it
 	 * it was last accessed. Return false if the bucket has run out of tokens.
 	 */
-	b = get_bucket(inst, id);
-	update_bucket_tokens(b, inst->tokenmax, inst->refreshrate);
-	if (b->tokens <= 0) {
+	b = *get_bucket(inst, id);
+	update_bucket_tokens(&b, inst->tokenmax, inst->refreshrate);
+	if (*(b.ntokens) <= 0) {
+		log_ratelimit(&b, id, inst->lograte);
 		return false;
 	}
 
 	/* the request is within limits - update the bucket and return "OK" (true) */
-	update_used_bucket(b);
+	update_used_bucket(&b);
 	return true;
 }
 
 /*
  * log_ratelimit logs the ratelimit event for the RatelimitID.
+ * logs are written is determined by the "lograte".
  */
-static void log_ratelimit(RatelimitID id) {
-	WARN("ratelimit: request id %s ratelimited", id.key);
+static void log_ratelimit(Bucket *b, RatelimitID id, uint32_t lograte) {
+	uint64_t now = current_time_in_sec();
+	if (*(b->lastlogged) + lograte <= current_time_in_sec()) {
+		WARN("ratelimit: request id %s ratelimited", id.key);
+		*(b->lastlogged) = now;
+	}
 }
 
 /*
@@ -186,6 +193,7 @@ static int mod_instantiate(UNUSED CONF_SECTION *conf, void *instance) {
 	rad_assert(inst->refreshrate > 0);
 
 	inst->datastore = ratelimit_init_datastore(inst);
+	rad_assert(inst->datastore != NULL);
 	if (inst->datastore == NULL) {
 		return -1;
 	}
@@ -301,7 +309,6 @@ static rlm_rcode_t CC_HINT(nonnull) mod_pre_proxy(void *instance, REQUEST *reque
 		if (ok == 0) {
 			DEBUG("ratelimit: id returned from request: %s", id.key);
 			if (!ratelimit_ok(inst, id)) {
-				log_ratelimit(id);
 				return RLM_MODULE_REJECT;
 			}
 		} else {

--- a/src/modules/rlm_ratelimit/rlm_ratelimit.h
+++ b/src/modules/rlm_ratelimit/rlm_ratelimit.h
@@ -1,0 +1,56 @@
+
+/*
+ *   This program is is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or (at
+ *   your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/**
+ * $Id$
+ *
+ * @file rlm_ratelimit.h
+ * @brief Allow FreeRADIUS to rate limit requests.
+ *
+ * @copyright 2024 The FreeRADIUS server project
+ * @copyright 2024 your name \<your address\>
+ */
+RCSIDH(ratelimit_h, "$Id$")
+
+#include <freeradius-devel/radiusd.h>
+#include <freeradius-devel/modules.h>
+#include <freeradius-devel/rad_assert.h>
+
+/*
+ *	Define a structure for our module configuration.
+ *
+ *	These variables do not need to be in a structure, but it's
+ *	a lot cleaner to do so, and a pointer to the structure can
+ *	be used as the instance handle.
+ */
+typedef struct rlm_ratelimit_t {
+	uint32_t tokenmax;
+	uint32_t refreshrate;
+	uint32_t datastoresize;
+
+	void *datastore;
+} rlm_ratelimit_t;
+
+/**
+ *	A mapping of configuration parameter to internal variables.
+ */
+static const CONF_PARSER module_config[] = {
+	{ "tokenmax", FR_CONF_OFFSET(PW_TYPE_INTEGER, rlm_ratelimit_t, tokenmax), "10" },
+	{ "refreshrate", FR_CONF_OFFSET(PW_TYPE_INTEGER, rlm_ratelimit_t, refreshrate), "5" },
+	{ "datastoresize", FR_CONF_OFFSET(PW_TYPE_INTEGER, rlm_ratelimit_t, datastoresize), "16777215" },
+	CONF_PARSER_TERMINATOR
+};

--- a/src/modules/rlm_ratelimit/rlm_ratelimit.h
+++ b/src/modules/rlm_ratelimit/rlm_ratelimit.h
@@ -38,8 +38,9 @@ RCSIDH(ratelimit_h, "$Id$")
  *	be used as the instance handle.
  */
 typedef struct rlm_ratelimit_t {
-	uint32_t tokenmax;
-	uint32_t refreshrate;
+	uint32_t tokenmax;		// max number of rate limit tokens per bucket
+	uint32_t refreshrate;	// how frequently bucket tokens are replenished
+	uint32_t lograte;		// how frequently rate limit warnings are repeated
 	uint32_t datastoresize;
 
 	void *datastore;
@@ -51,6 +52,7 @@ typedef struct rlm_ratelimit_t {
 static const CONF_PARSER module_config[] = {
 	{ "tokenmax", FR_CONF_OFFSET(PW_TYPE_INTEGER, rlm_ratelimit_t, tokenmax), "10" },
 	{ "refreshrate", FR_CONF_OFFSET(PW_TYPE_INTEGER, rlm_ratelimit_t, refreshrate), "5" },
+	{ "lograte", FR_CONF_OFFSET(PW_TYPE_INTEGER, rlm_ratelimit_t, lograte), "5" },
 	{ "datastoresize", FR_CONF_OFFSET(PW_TYPE_INTEGER, rlm_ratelimit_t, datastoresize), "16777215" },
 	CONF_PARSER_TERMINATOR
 };

--- a/src/modules/rlm_ratelimit/rlm_ratelimit.h
+++ b/src/modules/rlm_ratelimit/rlm_ratelimit.h
@@ -30,7 +30,7 @@ RCSIDH(ratelimit_h, "$Id$")
 #include <freeradius-devel/modules.h>
 #include <freeradius-devel/rad_assert.h>
 
-/*
+/**
  *	Define a structure for our module configuration.
  *
  *	These variables do not need to be in a structure, but it's


### PR DESCRIPTION
 These formats are supported:

  "8C:F0:71:C0:00:26"
  "8C-F0-71-C0-00-26"
  "8CF071C00026"
  "8CF0.71C0.0026"