### PR TITLE
Rate limit: memory fix

### DIFF
--- a/src/modules/rlm_ratelimit/fixedds.h
+++ b/src/modules/rlm_ratelimit/fixedds.h
@@ -26,11 +26,12 @@
 RCSIDH(fixedds_h, "$Id$")
 
 #include <freeradius-devel/radiusd.h>
+#include <arpa/inet.h>
 
 enum IDType { NONE, MACADDR, IPV4, IPV6 };
 
 typedef struct RatelimitID {
-	const char *key;
+	char key[INET6_ADDRSTRLEN];
 	enum IDType key_type;
 } RatelimitID;
 

--- a/src/modules/rlm_ratelimit/rlm_ratelimit.c
+++ b/src/modules/rlm_ratelimit/rlm_ratelimit.c
@@ -272,7 +272,6 @@ static int mod_detach(void *instance) {
 static int CC_HINT(nonnull) id_from_request(RatelimitID *id, const REQUEST *request) {
 	const VALUE_PAIR *vp;
 	const char *ip;
-	char buffer[128];
 
 	/* create the ID from the calling_station_id if present */
 	vp = fr_pair_find_by_num(request->packet->vps, PW_CALLING_STATION_ID, 0, TAG_ANY);
@@ -283,9 +282,11 @@ static int CC_HINT(nonnull) id_from_request(RatelimitID *id, const REQUEST *requ
 	}
 
 	/* no calling_station_id attribute so fall back to using the src_ip (ipv4 or ipv6) */
-	ip = inet_ntop(request->packet->src_ipaddr.af, &request->packet->src_ipaddr.ipaddr, buffer, sizeof(buffer));
+	ip = inet_ntop(request->packet->src_ipaddr.af,
+	        &request->packet->src_ipaddr.ipaddr,
+	        id->key,
+	        INET6_ADDRSTRLEN);
 	if (ip) {
-		id->key = ip;
 		if (request->packet->src_ipaddr.af == AF_INET) {
 			id->key_type = IPV4;
 		} else if (request->packet->src_ipaddr.af == AF_INET6) {

--- a/src/modules/rlm_ratelimit/rlm_ratelimit.c
+++ b/src/modules/rlm_ratelimit/rlm_ratelimit.c
@@ -97,7 +97,7 @@ static void update_bucket_tokens(Bucket *b, uint32_t maxtokens, uint32_t refresh
  * tokens_to_add returns the number of tokens to add for the elapse time for the update_period
  */
 static uint tokens_to_add(uint64_t elapsed, uint32_t refreshrate) {
-	DEBUG("ratelimit: tokens_to_add(): elapsed: %llu refreshrate %d", elapsed, refreshrate);
+	DEBUG("ratelimit: tokens_to_add(): elapsed: %lu refreshrate %d", elapsed, refreshrate);
 	return elapsed / refreshrate;
 }
 
@@ -141,7 +141,7 @@ static Bucket *get_bucket(Bucket *buffer, rlm_ratelimit_t *inst, const Ratelimit
 		INFO("ratelimit: after add_bucket tokens %d", *(b->ntokens));
 	}
 
-	DEBUG("ratelimit: get_bucket(): %s %d %llu %llu", id.key, *(b->ntokens), *(b->lastaccessed), *(b->lastlogged));
+	DEBUG("ratelimit: get_bucket(): %s %d %lu %lu", id.key, *(b->ntokens), *(b->lastaccessed), *(b->lastlogged));
 	return b;
 }
 
@@ -276,7 +276,7 @@ static int CC_HINT(nonnull) id_from_request(RatelimitID *id, const REQUEST *requ
 	/* create the ID from the calling_station_id if present */
 	vp = fr_pair_find_by_num(request->packet->vps, PW_CALLING_STATION_ID, 0, TAG_ANY);
 	if (vp) {
-		id->key = vp->vp_strvalue;
+		strlcpy(id->key, vp->vp_strvalue, sizeof(id->key));
 		id->key_type = MACADDR;
 		return 0;
 	}


### PR DESCRIPTION
The `id_from_request` function is designed to inspect the request properties and update the value `id->key` (C string) to point to an identifier for this session - either the MAC address of the supplicant, as specified in the Calling-Station-Id attribute, or the IP address of the RADIUS client, as discovered by the socket information.

The function had a problem with how it converted the IP address to a string.  The `inet_ntop` function will take a C-string buffer as input, and write the IP address into that buffer, while returning a pointer to that buffer.  The `id_from_request` function defined a char array in its local scope, and passed the address of that array in to `net_ntop` as the buffer.  (Thus, it returned a pointer to the buffer in the local scope.)  The function then assigned that returned pointer into `id->key`, meaning that `id->key` pointed to the address of the local buffer.  When the function finished, the local buffer was freed off the stack, and the memory pointed to by `id->key` became available for re-use.  Any use of `id->key` after this would have unpredictable results.

This change will instead define `id->key` as `char id[INET6_ADDRSTRLEN]` - a character array large enough to hold a string representation of the longest possible IPv6 address, plus a trailing NULL.  The `id_from_request` function now passes the address of `id->key` in to the `inet_ntop` function directly, eliminating the local buffer.

As a consequence of that, the `id_from_request` function also must copy the bytes of the MAC address over to `id->key`, instead of setting `id->key = vp->strvalue`.  Setting it doesn't make sense in the new context!